### PR TITLE
Added gd3 files to Makefile.xgmtool

### DIFF
--- a/gen_gcc/makefile-gen
+++ b/gen_gcc/makefile-gen
@@ -93,7 +93,7 @@ $(build_binutils): logdir
 	@echo "+++ Building $(src_dir) to $(build)..."
 	-mkdir -p $(build)
 	> $(log)
-	cd $(build); ../$(src_dir)/configure --target=$(target) --prefix=$(prefix) --enable-install-libbfd $(to_log)
+	cd $(build); ../$(src_dir)/configure --target=$(target) --prefix=$(prefix) --enable-install-libbfd --disable-werror $(to_log)
 	$(MAKE) -C $(build) all install DESTDIR=$(DESTDIR) $(to_log)
 	$(clean_up)
 

--- a/sgdk/files/Makefile.xgmtool
+++ b/sgdk/files/Makefile.xgmtool
@@ -40,9 +40,9 @@ OBJDIR_DEBUG = out
 DEP_DEBUG = 
 OUT_DEBUG = out/xgmtool
 
-OBJ_RELEASE = $(OBJDIR_RELEASE)/src/psg.o $(OBJDIR_RELEASE)/src/ym2612.o $(OBJDIR_RELEASE)/src/xgmtool.o $(OBJDIR_RELEASE)/src/xgmsmp.o $(OBJDIR_RELEASE)/src/xgmcom.o $(OBJDIR_RELEASE)/src/xgm.o $(OBJDIR_RELEASE)/src/xgccom.o $(OBJDIR_RELEASE)/src/xgc.o $(OBJDIR_RELEASE)/src/vgmcom.o $(OBJDIR_RELEASE)/src/vgm.o $(OBJDIR_RELEASE)/src/util.o $(OBJDIR_RELEASE)/src/samplebank.o
+OBJ_RELEASE = $(OBJDIR_RELEASE)/src/psg.o $(OBJDIR_RELEASE)/src/ym2612.o $(OBJDIR_RELEASE)/src/xgmtool.o $(OBJDIR_RELEASE)/src/xgmsmp.o $(OBJDIR_RELEASE)/src/xgmcom.o $(OBJDIR_RELEASE)/src/xgm.o $(OBJDIR_RELEASE)/src/xgccom.o $(OBJDIR_RELEASE)/src/xgc.o $(OBJDIR_RELEASE)/src/vgmcom.o $(OBJDIR_RELEASE)/src/vgm.o $(OBJDIR_RELEASE)/src/util.o $(OBJDIR_RELEASE)/src/samplebank.o $(OBJDIR_RELEASE)/src/gd3.o
 
-OBJ_DEBUG = $(OBJDIR_DEBUG)/src/psg.o $(OBJDIR_DEBUG)/src/ym2612.o $(OBJDIR_DEBUG)/src/xgmtool.o $(OBJDIR_DEBUG)/src/xgmsmp.o $(OBJDIR_DEBUG)/src/xgmcom.o $(OBJDIR_DEBUG)/src/xgm.o $(OBJDIR_DEBUG)/src/xgccom.o $(OBJDIR_DEBUG)/src/xgc.o $(OBJDIR_DEBUG)/src/vgmcom.o $(OBJDIR_DEBUG)/src/vgm.o $(OBJDIR_DEBUG)/src/util.o $(OBJDIR_DEBUG)/src/samplebank.o
+OBJ_DEBUG = $(OBJDIR_DEBUG)/src/psg.o $(OBJDIR_DEBUG)/src/ym2612.o $(OBJDIR_DEBUG)/src/xgmtool.o $(OBJDIR_DEBUG)/src/xgmsmp.o $(OBJDIR_DEBUG)/src/xgmcom.o $(OBJDIR_DEBUG)/src/xgm.o $(OBJDIR_DEBUG)/src/xgccom.o $(OBJDIR_DEBUG)/src/xgc.o $(OBJDIR_DEBUG)/src/vgmcom.o $(OBJDIR_DEBUG)/src/vgm.o $(OBJDIR_DEBUG)/src/util.o $(OBJDIR_DEBUG)/src/samplebank.o $(OBJDIR_DEBUG)/src/gd3.o
 
 all: release debug
 
@@ -95,6 +95,9 @@ $(OBJDIR_RELEASE)/src/util.o: src/util.c
 $(OBJDIR_RELEASE)/src/samplebank.o: src/samplebank.c
 	$(CC) $(CFLAGS_RELEASE) $(INC_RELEASE) -c src/samplebank.c -o $(OBJDIR_RELEASE)/src/samplebank.o
 
+$(OBJDIR_RELEASE)/src/gd3.o: src/gd3.c
+	$(CC) $(CFLAGS_RELEASE) $(INC_RELEASE) -c src/gd3.c -o $(OBJDIR_RELEASE)/src/gd3.o
+
 clean_release: 
 	rm -f $(OBJ_RELEASE) $(OUT_RELEASE)
 	rm -rf out
@@ -146,6 +149,9 @@ $(OBJDIR_DEBUG)/src/util.o: src/util.c
 
 $(OBJDIR_DEBUG)/src/samplebank.o: src/samplebank.c
 	$(CC) $(CFLAGS_DEBUG) $(INC_DEBUG) -c src/samplebank.c -o $(OBJDIR_DEBUG)/src/samplebank.o
+
+$(OBJDIR_DEBUG)/src/gd3.o: src/gd3.c
+	$(CC) $(CFLAGS_DEBUG) $(INC_DEBUG) -c src/gd3.c -o $(OBJDIR_DEBUG)/src/gd3.o
 
 clean_debug: 
 	rm -f $(OBJ_DEBUG) $(OUT_DEBUG)


### PR DESCRIPTION
Latest SGDK commit adds gd3.c to xgmtool so this change is required to build it

Also added --disable-werror for binutils
