### PR TITLE
Use 64-bit Ubuntu as 32-bit is no longer available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM 32bit/ubuntu:14.04
+FROM ubuntu:14.04
 
 WORKDIR /tmp
 
-RUN apt-get update && apt-get install -y build-essential wget unzip unrar texinfo git && apt-get clean
+RUN apt-get update && apt-get install -y build-essential wget unzip unrar-free texinfo git && apt-get clean
 
 RUN bash -c "git clone https://github.com/kubilus1/gendev.git && cd gendev && make && rm -rf /tmp/*"
 


### PR DESCRIPTION
This should fix building of the docker image. Also updated to use the free version of unrar (unrar-free) which is available in the Ubuntu universe repository. 'unrar' only exists in the multiverse.